### PR TITLE
Reintroduce shulkerboxtooltip, mods tracking file & minor updates

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -117,17 +117,17 @@ metafile = true
 
 [[files]]
 file = "mods/wthit.pw.toml"
-hash = "6a14837964ef9cc9331861888f625a179d56d218911ffc3ca3fec8ad391e8427"
+hash = "2aa625571aabc818aa63a8687d0c7ccd35598a0c29cb650b43cc0d0398d27c67"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-minimap.pw.toml"
-hash = "bf515dd35ac4ab39fa9a55867d3a60996e6892022c768af7e9d826630cceaf87"
+hash = "18418aef5c149099a076f260e03b58d4ee6c66be1892e277bd537ef5ccbc4d4f"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-world-map.pw.toml"
-hash = "6a697c45c567ce3004f8fd3a50719abfdbc686f7a0fdf46d2baa93a44384ac2e"
+hash = "5cd8d209bd8e41db87a72bf1e5890ba34e3d2017bb6ddbdff5182588a3fc4e93"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -91,6 +91,11 @@ hash = "b2e3be698473bfb3f08865a11e74c9ee8d47239ac72a79d60acc1ee381722a50"
 metafile = true
 
 [[files]]
+file = "mods/shulkerboxtooltip.pw.toml"
+hash = "35ba35c335a949965b9aa0b696afc0230eadcb0d61c1d5adfad6a7341c29bdad"
+metafile = true
+
+[[files]]
 file = "mods/sodium-extra.pw.toml"
 hash = "fd4f2019c75f05a79a031e1e8e640e202fa1f6807f93eaa013d923db3b477e60"
 metafile = true

--- a/mods.md
+++ b/mods.md
@@ -1,0 +1,52 @@
+# Mods
+This document contains all mods used in the modpack. This is mostly used internally to keep track of what mods are used accross versions.
+
+## List
+Below list is first sorted by version, then by name.
+
+| Name                  | Link(s)                                                                                                                                     | Last pack version (minecraft version) |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| Appleskin             | [Modrinth](https://modrinth.com/mod/appleskin) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/appleskin)                         | 1.19.3            |
+| Architectury-api      | [Modrinth](https://modrinth.com/mod/architectury-api) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/architectury-api)           | 1.19.3            |
+| Badpackets            | [Modrinth](https://modrinth.com/mod/badpackets) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/badpackets)                       | 1.19.3            |
+| Borderless-mining     | [Modrinth](https://modrinth.com/mod/borderless-mining) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/borderless-mining)         | 1.19.3            |
+| Ferrite-core          | [Modrinth](https://modrinth.com/mod/ferrite-core) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/ferritecore-fabric)             | 1.19.3            |
+| Fps-reducer           | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/fps-reducer)                                                                      | 1.19.3            |
+| Indium                | [Modrinth](https://modrinth.com/mod/indium) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/indium)                               | 1.19.3            |
+| Iris                  | [Modrinth](https://modrinth.com/mod/iris) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/irisshaders)                            | 1.19.3            |
+| Lazydfu               | [Modrinth](https://modrinth.com/mod/lazydfu) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/lazydfu)                             | 1.19.3            |
+| Lithium               | [Modrinth](https://modrinth.com/mod/lithium) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/lithium)                             | 1.19.3            |
+| Modmenu               | [Modrinth](https://modrinth.com/mod/modmenu) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/modmenu)                             | 1.19.3            |
+| Mouse-wheelie         | [Modrinth](https://modrinth.com/mod/mouse-wheelie) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/mouse-wheelie)                 | 1.19.3            |
+| qsl                   | [Modrinth](https://modrinth.com/mod/qsl) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/qsl)                                     | 1.19.3            |
+| reeses-sodium-options | [Modrinth](https://modrinth.com/mod/reeses-sodium-options) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/reeses-sodium-options) | 1.19.3            |
+| sodium                | [Modrinth](https://modrinth.com/mod/sodium) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/sodium)                               | 1.19.3            |
+| sodium-extra          | [Modrinth](https://modrinth.com/mod/sodium-extra) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/sodium-extra)                   | 1.19.3            |
+| starlight             | [Modrinth](https://modrinth.com/mod/starlight) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/starlight)                         | 1.19.3            |
+| wthit                 | [Modrinth](https://modrinth.com/mod/wthit) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/wthit)                                 | 1.19.3            |
+| wthit-plugins         | [Modrinth](https://modrinth.com/mod/wthit-plugins)                                                                                          | 1.19.3            |
+| xaeros-minimap        | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap)                                                                   | 1.19.3            |
+| xaeros-world-map      | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/xaeros-world-map)                                                                 | 1.19.3            |
+| shulkerboxtooltip     | [Modrinth](https://modrinth.com/mod/shulkerboxtooltip) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/shulkerboxtooltip)         | 1.19.3            |
+| continuity            | [Modrinth](https://modrinth.com/mod/continuity) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/continuity)                       | 1.19.2            |
+| ebe                   | [Modrinth](https://modrinth.com/mod/ebe) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/enhanced-block-entities)                 | 1.19.2            |
+| farsight-fabric       | [CurseForge](https://www.curseforge.com/minecraft/mc-mods/farsight-fabric)                                                                  | 1.19.2            |
+| lambdynamiclights     | [Modrinth](https://modrinth.com/mod/lambdynamiclights) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/lambdynamiclights)         | 1.19.2            |
+| light-overlay         | [Modrinth](https://modrinth.com/mod/light-overlay) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/light-overlay)                 | 1.19.2            |
+| ok-zoomer             | [Modrinth](https://modrinth.com/mod/ok-zoomer) [CurseForge](https://www.curseforge.com/minecraft/mc-mods/ok-zoomer)                         | 1.19.2            |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/mods/shulkerboxtooltip.pw.toml
+++ b/mods/shulkerboxtooltip.pw.toml
@@ -1,0 +1,13 @@
+name = "ShulkerBoxTooltip [Fabric/Forge]"
+filename = "shulkerboxtooltip-fabric-3.2.3+1.19.3.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/2M01OLQq/versions/eqbglOsx/shulkerboxtooltip-fabric-3.2.3%2B1.19.3.jar"
+hash-format = "sha1"
+hash = "779f2edf8b41fb18fca7c1fe852ba6d009acfc19"
+
+[update]
+[update.modrinth]
+mod-id = "2M01OLQq"
+version = "eqbglOsx"

--- a/mods/wthit.pw.toml
+++ b/mods/wthit.pw.toml
@@ -1,13 +1,13 @@
 name = "WTHIT"
-filename = "wthit-quilt-6.1.0.jar"
+filename = "wthit-quilt-6.1.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/6AQIaxuO/versions/kFNIL4IR/wthit-quilt-6.1.0.jar"
+url = "https://cdn.modrinth.com/data/6AQIaxuO/versions/x0R2vZel/wthit-quilt-6.1.1.jar"
 hash-format = "sha1"
-hash = "1924ae4c76246e4b680dc01ff4585f318c9259b1"
+hash = "41f7405fc7d40a64177f7e38ff25ffafaa88df6a"
 
 [update]
 [update.modrinth]
 mod-id = "6AQIaxuO"
-version = "kFNIL4IR"
+version = "x0R2vZel"

--- a/mods/xaeros-minimap.pw.toml
+++ b/mods/xaeros-minimap.pw.toml
@@ -1,13 +1,13 @@
 name = "Xaero's Minimap"
-filename = "Xaeros_Minimap_22.16.3_Fabric_1.19.3.jar"
+filename = "Xaeros_Minimap_22.16.4_Fabric_1.19.3.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "6e9b973946e6425cbce7b242582d9b16313ed603"
+hash = "1a9e0f4976c3ad92bc594c08fb0dbcf7929f0635"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4147114
+file-id = 4167411
 project-id = 263420

--- a/mods/xaeros-world-map.pw.toml
+++ b/mods/xaeros-world-map.pw.toml
@@ -1,13 +1,13 @@
 name = "Xaero's World Map"
-filename = "XaerosWorldMap_1.28.4_Fabric_1.19.3.jar"
+filename = "XaerosWorldMap_1.28.5_Fabric_1.19.3.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "f5ca03ccfaa413ca0a64d0bde639d4c2a8a06f04"
+hash = "20db00ac2ad235550c625fff6afb585c0f6d5c80"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4147119
+file-id = 4167415
 project-id = 317780

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "c2e2edfc1f654745305c10b5cea8fbace0375afa3f833e94d2025bd07ae2bcfe"
+hash = "c622863f71c3d5d2e7c4926b0c2be51ecc8c0091af263a1f5bce577ae896e9fe"
 
 [versions]
 minecraft = "1.19.3"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "c21b4ff8e70718eea391c1ec2818543cc2c00d3c87cce49b07e61110c60a2cbe"
+hash = "c2e2edfc1f654745305c10b5cea8fbace0375afa3f833e94d2025bd07ae2bcfe"
 
 [versions]
 minecraft = "1.19.3"


### PR DESCRIPTION
* The shulkerboxtooltip mod was updated to 1.19.3 and was present in the 1.19.2 pack. It is now reintroduced.
* In order to track what mods were used in what versions of the pack the `mods.md` file has been created. This is mostly used internally to see if any removed mods have been updated and can be reintroduced.
* Updated both Xaero's map mods and WTHIT mod.